### PR TITLE
Using the new LaunchDarkly Javascript SDK

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,18 @@
 {
   "presets": [
     [
-      "env",
+      "@babel/preset-env",
       {
         "modules": false
       }
     ],
-    "stage-0",
-    "react"
+    "@babel/preset-react"
   ],
   "plugins": [
-    "external-helpers",
+    "@babel/plugin-external-helpers",
     [
-      "transform-runtime",
+      "@babel/plugin-transform-runtime",
       {
-        "polyfill": false,
         "regenerator": true
       }
     ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "extends": ["standard", "standard-react"],
   "env": {
     "es6": true,

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist
 .env.development.local
 .env.test.local
 .env.production.local
+.playground
 
 npm-debug.log*
 yarn-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ import FlagsConsumer from "./src/FlagsConsumer";
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [1.3.0] - 2023-08-01
+This release uses the new LaunchDarkly Javascript SDK.
+
 ## [1.2.0] - 2020-11-30
 This release allows you to use ld-react-feature-flags with React 18 without a warning when installing.
 

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-highlight": "^0.12.0",
-    "react-scripts": "^1.1.5"
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -23,5 +23,17 @@
   },
   "devDependencies": {
     "prettier": "1.13.6"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lectra/ld-react-feature-flags",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Integrate Launch Darkly in your React app in a breeze",
   "contributors": [
     {
@@ -33,7 +33,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "dependencies": {
-    "ldclient-js": "^2.7.3"
+    "launchdarkly-js-client-sdk": "^3.1.3"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",
@@ -41,25 +41,28 @@
     "react-dom": "^16.3.0 || ^17 || ^18"
   },
   "devDependencies": {
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-commonjs": "^24.1.0",
+    "@rollup/plugin-node-resolve": "^15.0.2",
+    "@rollup/plugin-url": "^8.0.1",
     "@types/react": "^16.9.23",
-    "babel-core": "^6.26.0",
-    "babel-eslint": "^8.2.1",
-    "babel-plugin-external-helpers": "^6.22.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
+    "@babel/core": "^7.21.8",
+    "@babel/eslint-parser": "^7.21.8",
+    "@babel/plugin-external-helpers": "^7.18.6",
+    "@babel/plugin-transform-runtime": "^7.21.4",
+    "@babel/preset-env": "^7.21.4",
+    "@babel/preset-react": "^7.18.6",
     "cross-env": "^5.1.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "enzyme-to-json": "^3.4.3",
-    "eslint": "^4.19.1",
+    "eslint": "^8.0.0",
     "eslint-config-standard": "^11.0.0",
     "eslint-config-standard-react": "^6.0.0",
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.7.0",
-    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-react": "^7.32.0",
     "eslint-plugin-standard": "^3.0.1",
     "gh-pages": "^1.1.0",
     "husky": "^0.14.3",
@@ -68,16 +71,12 @@
     "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-scripts": "^1.1.1",
+    "react-scripts": "^5.0.1",
     "react-test-renderer": "^16.6.3",
-    "rollup": "^0.54.0",
-    "rollup-plugin-babel": "^3.0.3",
-    "rollup-plugin-commonjs": "^8.2.1",
-    "rollup-plugin-cpy": "^1.1.0",
-    "rollup-plugin-node-resolve": "^3.3.0",
-    "rollup-plugin-peer-deps-external": "^2.0.0",
-    "rollup-plugin-postcss": "^1.1.0",
-    "rollup-plugin-url": "^1.3.0"
+    "rollup": "^3.21.5",
+    "rollup-plugin-cpy": "^2.0.1",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-postcss": "^4.0.2"
   },
   "files": [
     "dist"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,12 +1,14 @@
-import babel from 'rollup-plugin-babel';
-import commonjs from 'rollup-plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
 import external from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
-import resolve from 'rollup-plugin-node-resolve';
-import url from 'rollup-plugin-url';
+import resolve from '@rollup/plugin-node-resolve';
+import url from '@rollup/plugin-url';
 import copy from 'rollup-plugin-cpy';
 
-import pkg from './package.json';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const pkg = require('./package.json');
 
 export default {
   input: 'src/index.js',
@@ -17,7 +19,7 @@ export default {
     },
     {
       file: pkg.module,
-      format: 'es'
+      format: 'esm'
     }
   ],
   plugins: [
@@ -27,7 +29,7 @@ export default {
     }),
     url(),
     babel({
-      runtimeHelpers: true,
+      babelHelpers: 'runtime',
       exclude: 'node_modules/**'
     }),
     resolve(),

--- a/src/FlagsProvider.js
+++ b/src/FlagsProvider.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { initialize as Client } from 'ldclient-js';
+import { initialize as Client } from 'launchdarkly-js-client-sdk';
 
 import { FlagsContext } from './FlagsContext';
 
@@ -33,7 +33,15 @@ export default class FlagsProvider extends Component {
 
   async componentDidMount() {
     const { clientkey, user, bootstrap, onFlagsChange } = this.props;
-    this.ldClient = await Client(clientkey, user, bootstrap);
+    this.ldClient = await Client(
+      clientkey,
+      {
+        kind: 'user',
+        key: user.key,
+        ...user.custom
+      },
+      bootstrap
+    );
     await this.LDReadyEvent(this.ldClient);
 
     if (onFlagsChange) {

--- a/src/__tests__/FlagsProvider.spec.js
+++ b/src/__tests__/FlagsProvider.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import FlagsProvider from '../FlagsProvider';
 
-jest.mock('ldclient-js', () => {
+jest.mock('launchdarkly-js-client-sdk', () => {
   return {
     initialize: jest.fn().mockImplementation(() => {
       return Promise.resolve({

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LDClient } from 'ldclient-js';
+import { LDClient } from 'launchdarkly-js-client-sdk';
 
 declare module '@lectra/ld-react-feature-flags' {
   interface PropsFlag {


### PR DESCRIPTION
- Using `launchdarkly-js-client-sdk` library
- Using most up-to-date rollup plugins
- Using most up-to-date eslint plugins
- Using most up-to-date babel plugins